### PR TITLE
Initial support to run tests under tox

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,6 @@
+- project:
+    check:
+      jobs:
+        - tox-py27:
+            required-projects:
+              - name: github.com/ansible-network/network-engine

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 arista_eos
 ===============================
 
+2.6.2
+=====
+
+Major Changes
+-------------
+
+- Added configure_vlan task
+- Replace eos_config_file to config_manager_file
+
 2.6.1
 =====
 

--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -2,7 +2,7 @@
 - name: set role basic facts
   set_fact:
     ansible_network_eos_path: "{{ role_path }}"
-    ansible_network_eos_version: "devel"
+    ansible_network_eos_version: "v2.6.2"
 
 - name: display the role version to stdout
   debug:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+host_key_checking = False
+roles_path = ../..

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,1 @@
 localhost
-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,4 @@
 ---
 - hosts: localhost
-  remote_user: root
   roles:
-    - ansible-network.arista_eos
+    - arista_eos

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE(pabelanger): Create a symlink for ansible-network.network-engine to keep
+# meta/main.yml happy
+ln -s ~/src/github.com/ansible-network/network-engine \
+  ~/src/github.com/ansible-network/ansible-network.network-engine

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,17 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = linters
+envlist = linters,py27,py36
 
 [testenv]
 install_command = pip install {opts} {packages}
-deps = -r{toxinidir}/test-requirements.txt
+commands =
+  ansible-playbook -i tests/inventory tests/test.yml
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
+setenv =
+  ANSIBLE_CONFIG = tests/ansible.cfg
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
This is our first attempt at running tests under tox. Here we need to
add a required-projects entry for zuul, so we can also ensure
network-engine is on disk.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>